### PR TITLE
Gebruikersacceptatie test aanpassingen 20240508

### DIFF
--- a/Common/Json/translations.json
+++ b/Common/Json/translations.json
@@ -1,7 +1,7 @@
 [
   {
     "Key": "Scan_ticket",
-    "Value": "Scan uw [darkorange]ticket[/]:",
+    "Value": "Scan uw [darkorange]bezoekersticket[/]:",
     "Locale": "nl-NL",
     "Id": 1
   },
@@ -19,13 +19,13 @@
   },
   {
     "Key": "Kiosk_modification",
-    "Value": "Reservering [darkorange]wijzigen[/]",
+    "Value": "Bestaande reservering [darkorange]wijzigen[/]",
     "Locale": "nl-NL",
     "Id": 4
   },
   {
     "Key": "Kiosk_cancellation",
-    "Value": "Reservering [red]verwijderen[/]",
+    "Value": "Bestaande reservering [red]verwijderen[/]",
     "Locale": "nl-NL",
     "Id": 5
   },
@@ -109,13 +109,13 @@
   },
   {
     "Key": "Scan_userpass",
-    "Value": "Scan uw [darkorange]pas[/]:",
+    "Value": "Scan uw [darkorange]personeelspas[/]:",
     "Locale": "nl-NL",
     "Id": 19
   },
   {
     "Key": "Invalid_userpass",
-    "Value": "[red]Ongeldige pas[/]",
+    "Value": "[red]Ongeldige personeelspas[/]",
     "Locale": "nl-NL",
     "Id": 20
   },
@@ -439,7 +439,7 @@
   },
   {
     "Key": "Guide_start_tour",
-    "Value": "Rondleiding [green]starten[/]",
+    "Value": "[green]Begin[/] rondleiding en voeg deelnemers toe",
     "Locale": "nl-NL",
     "Id": 74
   },
@@ -559,7 +559,7 @@
   },
   {
     "Key": "Scan_ticket_or_userpass",
-    "Value": "Scan [darkorange]bezoekersticket[/] of [darkorange]pas[/]:",
+    "Value": "Scan [darkorange]bezoekersticket[/] of de [darkorange]personeelspas[/] om de rondleiding te starten:",
     "Locale": "nl-NL",
     "Id": 94
   },


### PR DESCRIPTION
- [ ] Bezoeker aangepast: Scan bezoekersticket ipv ticket (consistent met de rest van de tekst)
- [ ] Bezoeker aangepast: Bestaande reservering wijzigen/annuleren ipv reservering wijzigen/annuleren
- [ ] Manager & Gids aangepast: Scan uw personeelspas ipv scan uw pas (consistent aangepast).
- [ ] Gids aangepast: Begin rondleiding en voeg deelnemers toe ipv begin rondleiding 
- [ ] Gids aangepast: Bij extra tickets toevoegen de tekst veranderd in "Scan een bezoekers ticket of scan de personeelspas om verder te gaan met het starten van de rondleiding"